### PR TITLE
GLO-26: Show price unit on clinic procedure estimates

### DIFF
--- a/src/components/ConsultationRequestForm.jsx
+++ b/src/components/ConsultationRequestForm.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { CONSULTATION_REQUEST_API_URL } from "../config/api";
 import { captureEvent } from "../config/analytics";
 import { cn } from "../utils/cn";
+import { formatClinicEstimatePrice } from "../utils/procedurePrice";
 
 const ConsultationRequestForm = ({ 
   clinicId, 
@@ -229,7 +230,7 @@ const ConsultationRequestForm = ({
             {selectedData.map((item) => (
               <div key={item.id} className="flex justify-between items-center text-sm">
                 <span className="text-gray-800">{item.name}</span>
-                <span className="font-medium text-black">{formatPrice(item.price)}</span>
+                <span className="font-medium text-black">{formatClinicEstimatePrice(item.price, item)}</span>
               </div>
             ))}
           </div>

--- a/src/components/ConsultationRequestModal.jsx
+++ b/src/components/ConsultationRequestModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { CONSULTATION_REQUEST_API_URL } from "../config/api";
 import { cn } from "../utils/cn";
+import { formatClinicEstimatePrice } from "../utils/procedurePrice";
 import "./ConsultationRequestModal.css";
 
 const ConsultationRequestModal = ({ 
@@ -312,7 +313,7 @@ const ConsultationRequestModal = ({
                     {selectedData.map((item) => (
                       <div key={item.id} className="consultation-modal-item-row">
                         <span>{item.name}</span>
-                        <span className="consultation-modal-item-price">{formatPrice(item.price)}</span>
+                        <span className="consultation-modal-item-price">{formatClinicEstimatePrice(item.price, item)}</span>
                       </div>
                     ))}
                   </div>

--- a/src/pages/clinic/components/ClinicProcedures.jsx
+++ b/src/pages/clinic/components/ClinicProcedures.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { clinicIcons } from "../../../components/Icons";
+import { formatClinicEstimatePrice } from "../../../utils/procedurePrice";
 
 const ClinicProcedures = ({ procedures, selectedData, setSelectedData }) => {
 	const location = useLocation();
@@ -218,16 +219,6 @@ const ClinicProcedureTable = ({
 		);
 	};
 
-	// Formatting functions with tilde prefix
-	const formatPrice = (price) => {
-		return '~' + new Intl.NumberFormat('en-US', {
-			style: 'currency',
-			currency: 'USD',
-			minimumFractionDigits: 0,
-			maximumFractionDigits: 0,
-		}).format(price);
-	};
-
 	return (
 		<>
 			<div className="procedure-table-card">
@@ -279,7 +270,7 @@ const ClinicProcedureTable = ({
 											</td>
 											<td className="price-cell py-2">
 												<span className="text-sm font-medium text-black">
-													{formatPrice(item.price)}+
+													{formatClinicEstimatePrice(item.price, item)}+
 												</span>
 											</td>
 											<td className="action-cell py-2 pl-2">

--- a/src/pages/clinic/components/ClinicRightSidebar.jsx
+++ b/src/pages/clinic/components/ClinicRightSidebar.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import ConsultationRequestModal from "../../../components/ConsultationRequestModal";
 import ConsultationRequestForm from "../../../components/ConsultationRequestForm";
 import useScreen from "../../../hooks/useScreen";
+import { formatClinicEstimatePrice } from "../../../utils/procedurePrice";
 
 const ClinicRightSidebar = ({ selectedData, clinicInfo, clinicId, procedures }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -58,7 +59,7 @@ const ClinicRightSidebar = ({ selectedData, clinicInfo, clinicId, procedures }) 
                     {item.name}
                   </span>
                   <span className="text-gray-900 font-semibold whitespace-nowrap flex-shrink-0">
-                    {formatPrice(item.price)}
+                    {formatClinicEstimatePrice(item.price, item)}
                   </span>
                 </div>
               ))}

--- a/src/utils/procedurePrice.js
+++ b/src/utils/procedurePrice.js
@@ -1,0 +1,41 @@
+/**
+ * Human-readable suffix from stored unit values (e.g. "/unit" from PRICE_UNITS).
+ * @param {string|undefined|null} unitRaw
+ * @returns {string} e.g. "per unit", or "" if none
+ */
+export function getProcedureUnitLabel(unitRaw) {
+  const u = typeof unitRaw === 'string' ? unitRaw.trim() : '';
+  if (!u) return '';
+  if (u.startsWith('/')) return `per ${u.slice(1)}`;
+  return u;
+}
+
+/**
+ * @param {object} item - Procedure from API (may use name or procedureName; priceUnit or unit)
+ * @returns {string|undefined|null}
+ */
+export function getProcedurePriceUnit(item) {
+  if (!item || typeof item !== 'object') return '';
+  return item.priceUnit ?? item.unit ?? '';
+}
+
+/**
+ * Formats a clinic procedure estimate: ~$12 or ~$12 / per unit (no trailing +).
+ * @param {number} price
+ * @param {object} [item]
+ * @returns {string}
+ */
+export function formatClinicEstimatePrice(price, item) {
+  const formatted =
+    '~' +
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(price);
+
+  const unitLabel = getProcedureUnitLabel(getProcedurePriceUnit(item));
+  if (!unitLabel) return formatted;
+  return `${formatted} / ${unitLabel}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clinic procedure rows now append the stored unit (for example `/unit` from admin data becomes **/ per unit**) after the formatted estimate, so Botox-style pricing reads like **~$12 / per unit+** instead of **~$12+** alone.

## Changes

- Added `src/utils/procedurePrice.js` with `formatClinicEstimatePrice` and helpers that accept both `priceUnit` and `unit` for API compatibility.
- Wired the formatter into the procedures pricing table, mobile sidebar selected-procedure lines, and the consultation estimate overview (desktop form + mobile modal).

## Testing

- `npm run build` (passes). No Jest tests in the repo.

## Notes

- Totals are unchanged (still sum of `price` only); mixed per-unit and flat procedures would need a product decision if we ever want a different total label.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GLO-26](https://linear.app/glowra/issue/GLO-26/add-unit-to-pricing-section-within-clinic)

<div><a href="https://cursor.com/agents/bc-e1edc9e2-785f-41ae-a890-9413c8a8fc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1edc9e2-785f-41ae-a890-9413c8a8fc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

